### PR TITLE
Let Paho mqtt client handle reconnection

### DIFF
--- a/bin/user/weewx-mqtt-input.py
+++ b/bin/user/weewx-mqtt-input.py
@@ -146,7 +146,6 @@ class WeewxMqttInputDriver(weewx.drivers.AbstractDevice):
         self.client = mqtt.Client()
         self.client.on_connect = self.on_connect
         self.client.on_message = self.on_message
-        self.client.on_disconnect = self.on_disconnect
         try:
             if self.username:
                 self.client.username_pw_set(self.username, self.password)
@@ -184,16 +183,6 @@ class WeewxMqttInputDriver(weewx.drivers.AbstractDevice):
                     topic, value, t.name))
                 return
         log.error("unknown topic '{}' value '{}'".format(topic, value))
-
-    # MQTT callback for disconnects
-    def on_disconnect(self, client, userdata, rc):
-        log.info("disconnected, result code {}".format(rc))
-        if self.run:
-            log.info("reconnecting to {}:{}...".format(self.address, self.port))
-            try:
-                self.client.connect(self.address, self.port, self.timeout)
-            except:
-                raise weewx.WeeWxIOError("Fatal error connecting to mqtt")
 
     # WeeWX generator where we return the measurements. We iterate all
     # topics, collecting all measurements of the same unit-type. This


### PR DESCRIPTION
We do not have to attempt reconnections on our own, as the Paho client will handle that automatically.

This solves a problem I've had with weewx stalling if mosquitto was restarted (e.g. on upgrade)